### PR TITLE
updated files to resolve runtime conflicts with dependencies

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -1,1 +1,1 @@
-from experiments import *
+from python.experiments import *

--- a/python/experiments.py
+++ b/python/experiments.py
@@ -2,10 +2,8 @@ import json
 import os
 from pathlib import Path
 from typing import List, Union
-import util
-import vivado
+from . import util, vivado, yosys
 import pandas
-import yosys
 
 
 def _collect_json_to_csv(

--- a/python/vivado.py
+++ b/python/vivado.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from time import time
 from typing import Any, Dict, Optional, Tuple, Union
-from util import count_resources_in_verilog_src
+from . import util
 
 
 def xilinx_ultrascale_plus_vivado_synthesis(

--- a/python/yosys.py
+++ b/python/yosys.py
@@ -6,9 +6,9 @@ import sys
 from time import time
 from typing import Any, Dict, Optional, Tuple, Union
 
-from util import count_resources_in_verilog_src
+from . import util
 
-
+ 
 def yosys_synthesis(
     input_filepath: Union[str, Path],
     module_name: str,

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ packaging==24.1
 pathspec==0.12.1
 platformdirs==4.2.2
 zipp==3.19.2
+pyyaml==6.0.2
+pandas==2.0.3


### PR DESCRIPTION
This is a couple of quick changes that should resolve runtime issues faced by new users of the Churchroad eval. They were changes I encountered and had to fix to get the `doit` command working, and so I imagine that including the fixes in the Churchroad eval would help other users get acquainted.

### What this change does:
It updates various dependency-related files, such as `requirements.txt`, such that running the command `pip install -r requirements.txt` correctly finds and identifies all packages required for running the `doit` command on a fresh install. It also changes how some of the Python files access other modules.

### How this change does it:
It adds two lines in `requirements.txt`, as well as modifies how some of the Python source files access modules for importing. In particular, some of them had to have the `from . import foo` structure because `doit` runs from a separate folder than the actual Python files/modules.
